### PR TITLE
Add more crate metadata

### DIFF
--- a/.github/workflows/rust-workflow.yml
+++ b/.github/workflows/rust-workflow.yml
@@ -29,7 +29,7 @@ jobs:
 
   publish:
     needs: check
-    uses: famedly/backend-build-workflows/.github/workflows/publish-crate.yml@fd0845e44d45187e62d65e6af5b0193ccd655feb
+    uses: famedly/backend-build-workflows/.github/workflows/publish-crate.yml@689c5d0e77566542a20655600c7c0120a041af14
     with:
       registry-name: "crates-io"
       registry-index: "https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,13 @@
 [package]
 name = "famedly_rust_utils"
+description = "Random rust utility functions and types"
 version = "0.2.0"
 authors = []
 edition = "2021"
 resolver = "2"
-publish = ["famedly"]
+publish = ["crates-io"]
+license = "AGPL-3.0-only"
+repository = "https://github.com/famedly/famedly-rust-utils"
 
 [dependencies]
 reqwest = { version = "0.12.12", optional = true }


### PR DESCRIPTION
The `publish` key is necessary to permit publishing the crate to crates.io; we might as well add the license and repo while we're at it.

Fixes #13 