### PR TITLE
doc: Improve docs, fix formatting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,10 @@ resolver = "2"
 publish = ["crates-io"]
 license = "AGPL-3.0-only"
 repository = "https://github.com/famedly/famedly-rust-utils"
+documentation = "https://docs.rs/famedly_rust_utils/latest"
+
+[package.metadata.docs.rs]
+all-features = true
 
 [dependencies]
 reqwest = { version = "0.12.12", optional = true }

--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@
 [badge-rust-workflow-img]: https://github.com/famedly/famedly-rust-utils/actions/workflows/rust.yml/badge.svg
 [badge-rust-workflow-url]: https://github.com/famedly/famedly-rust-utils/commits/main
 
-Random rust utility functions and types. For docs see
-[`docs.rs/famedly_rust_utils`](https://docs.rs/famedly_rust_utils/latest/famedly_rust_utils/).
+Various rust utility functions and types originally developed for internal use at Famedly. For docs see [`docs.rs/famedly_rust_utils`](https://docs.rs/famedly_rust_utils/latest/famedly_rust_utils/).
 
 ## Lints
 

--- a/src/duration.rs
+++ b/src/duration.rs
@@ -1,4 +1,4 @@
-//! # Duration wrapper for serde
+//! # `Duration` wrapper for [`serde`]
 //!
 //! - `Ms<std::time::Duration>` - deserializes `u64` as milliseconds
 //! - `Seconds<std::time::Duration>` - deserializes `u64` as seconds
@@ -18,6 +18,7 @@ use std::time::Duration as StdDuration;
 use schemars::{
 	schema::InstanceType, schema::Schema, schema::SchemaObject, JsonSchema, SchemaGenerator,
 };
+use serde::Deserialize;
 
 #[doc(hidden)]
 macro_rules! define_generic_wrapper {
@@ -78,7 +79,7 @@ macro_rules! define_generic_wrapper {
 
 		$(
 			$( #[cfg(feature = $feat)] )?
-			impl<'de> serde::Deserialize<'de> for $name<$t> {
+			impl<'de> Deserialize<'de> for $name<$t> {
 				fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
 				where
 					D: serde::Deserializer<'de>,
@@ -94,7 +95,7 @@ macro_rules! define_generic_wrapper {
 use time::Duration as TimeDuration;
 
 define_generic_wrapper! {
-	"Helper wrapper to use in configs to deserialize durations from seconds",
+	"`Duration` wrapper with [`Deserialize`] impl",
 	Seconds:
 
 	{

--- a/src/level_filter.rs
+++ b/src/level_filter.rs
@@ -1,6 +1,7 @@
+//! [`Deserialize`] impl for [`tracing::level_filters::LevelFilter`]
 use serde::{de, Deserialize, Serialize};
 
-/// LevelFilter wrapper with from trait implementations for `tracing`.
+/// [`tracing::level_filters::LevelFilter`] wrapper with [`Deserialize`] impl.
 /// ```
 /// # use famedly_rust_utils::LevelFilter;
 /// use tracing::level_filters::LevelFilter as LF;
@@ -17,7 +18,6 @@ use serde::{de, Deserialize, Serialize};
 /// 	assert_eq!(tlvl, LF::from(lvl));
 /// }
 /// ```
-
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[repr(transparent)]
 pub struct LevelFilter(pub tracing::level_filters::LevelFilter);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,18 +1,31 @@
-//! Famedly rust utils
+#![cfg_attr(all(doc, not(doctest)), feature(doc_auto_cfg))]
+//! This crate consists of incohesive generic types and functions that are
+//! needed in almost every crate but are so small that making a separate crate
+//! for them is too much.
+//!
+//! See [`GenericCombinators`] for some useful generic methods.
+//!
+//! See [`LevelFilter`], [`BaseUrl`] and [`duration`] for useful wrapper types
+//! to use in your `serde`-based configs.
+//!
+//! Enable `schemars` feature to get [`schemars::JsonSchema`] impls for
+//! "config-helper" types to generate config schemas (for documentation and
+//! validation purposes).
 
-/// Workaround on [`url::Url::join` behavior](https://github.com/servo/rust-url/issues/333)
 mod base_url;
 pub mod duration;
-/// [serde::Deserialize] impl for [tracing::level_filters::LevelFilter]
 mod level_filter;
 #[cfg(feature = "reqwest")]
-/// Helpers for [reqwest]
 pub mod reqwest;
 
 pub use base_url::{BaseUrl, BaseUrlParseError};
 pub use level_filter::LevelFilter;
 
-/// Generic combinators
+/// Generic combinators on polymorphic unconstrained types that `std` lacks.
+///
+/// Since rust doesn't allow to define custom infix operators, the only way to
+/// achieve their convenience is `fn(&self, A) -> B` type of functions. This
+/// trait combines some useful operators for generic types.
 pub trait GenericCombinators {
 	/// Convenience method to cast everything into `()`. For example:
 	/// ```
@@ -67,7 +80,7 @@ pub trait GenericCombinators {
 		Self: Sized;
 
 	/// Helper method to inline optional steps in chains. Analogous to
-	/// [GenericCombinators::chain_if]
+	/// [`GenericCombinators::chain_if`]
 	/// ```
 	/// # use famedly_rust_utils::GenericCombinators;
 	/// # #[derive(Debug)]
@@ -140,9 +153,9 @@ impl<A> GenericCombinators for A {
 #[inline]
 pub fn ignore<X>(_: X) {}
 
-/// Extension to [Iterator]
+/// Extension to [`Iterator`]
 pub trait IteratorExt: Iterator {
-	/// Helper function for external types that lack `FromIterator`
+	/// Helper function for external types that lack [`FromIterator`]
 	/// implementation
 	/// ```
 	/// # use famedly_rust_utils::IteratorExt;

--- a/src/reqwest.rs
+++ b/src/reqwest.rs
@@ -1,28 +1,8 @@
+//! Helpers for [`reqwest`]
 use std::{fmt, future::Future};
 
-/// Wrapper around [reqwest::Error] with optional response body
-#[derive(Debug, thiserror::Error)]
-pub struct ReqwestErrorWithBody {
-	/// Error from [reqwest]
-	pub error: reqwest::Error,
-	/// Optional response body
-	pub body: Option<String>,
-}
-
-impl From<reqwest::Error> for ReqwestErrorWithBody {
-	fn from(error: reqwest::Error) -> ReqwestErrorWithBody {
-		Self { error, body: None }
-	}
-}
-
-impl fmt::Display for ReqwestErrorWithBody {
-	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-		write!(f, "{} with body {}", self.error, self.body.as_deref().unwrap_or("<no body>"))
-	}
-}
-
-/// An alternative to [reqwest::Resnpose::error_for_status] that also returns
-/// optional response body
+/// An alternative to [`reqwest::Response::error_for_status`] that also returns
+/// response body if it is present.
 /// ```no_run
 /// # use famedly_rust_utils::reqwest::*;
 /// # async fn mk_req() -> Result<(), ReqwestErrorWithBody> {
@@ -40,6 +20,27 @@ pub trait ErrorForStatusWithBody {
 	fn error_for_status_with_body(
 		self,
 	) -> impl Future<Output = Result<reqwest::Response, ReqwestErrorWithBody>> + Send;
+}
+
+/// Wrapper around [`reqwest::Error`] with optional response body
+#[derive(Debug, thiserror::Error)]
+pub struct ReqwestErrorWithBody {
+	/// Error from [`reqwest`]
+	pub error: reqwest::Error,
+	/// Optional response body
+	pub body: Option<String>,
+}
+
+impl From<reqwest::Error> for ReqwestErrorWithBody {
+	fn from(error: reqwest::Error) -> ReqwestErrorWithBody {
+		Self { error, body: None }
+	}
+}
+
+impl fmt::Display for ReqwestErrorWithBody {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		write!(f, "{} with body {}", self.error, self.body.as_deref().unwrap_or("<no body>"))
+	}
 }
 
 impl ErrorForStatusWithBody for reqwest::Response {


### PR DESCRIPTION
This is slightly breaking: `cargo doc` requires nightly rust (that docs.rs uses by default)