### PR TITLE
fix(features): Allow all feature subsets to compile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,13 +31,13 @@ dedent = "0.1.1"
 serde_json = "1.0.128"
 
 [features]
-config = ["dep:figment", "dep:serde"]
-level_filter = ["dep:tracing", "dep:serde"]
+config = ["dep:figment", "serde"]
+level_filter = ["dep:tracing"]
 reqwest = ["dep:reqwest", "dep:thiserror"]
 time = ["dep:time"]
 schemars = ["dep:schemars", "schemars/url"]
 serde = ["dep:serde"]
-base_url = ["dep:url", "dep:thiserror", "dep:serde"]
+base_url = ["dep:url", "dep:thiserror", "serde"]
 
 [lints.rust]
 dead_code = "warn"

--- a/src/level_filter.rs
+++ b/src/level_filter.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! [`Deserialize`] impl for [`tracing::level_filters::LevelFilter`]
+#[cfg(feature = "serde")]
 use serde::{de, Deserialize, Serialize};
 
 /// [`tracing::level_filters::LevelFilter`] wrapper with [`Deserialize`] impl.
@@ -32,6 +33,7 @@ impl std::fmt::Display for LevelFilter {
 	}
 }
 
+#[cfg(feature = "serde")]
 impl Serialize for LevelFilter {
 	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
 	where
@@ -41,6 +43,7 @@ impl Serialize for LevelFilter {
 	}
 }
 
+#[cfg(feature = "serde")]
 impl<'de> Deserialize<'de> for LevelFilter {
 	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
 	where


### PR DESCRIPTION
A half-applied suggestion from review during the release PR in #31 broke features that depend on serde. Since we have to fix this anyway, might as well go all the way and set features to depend on each other, and boot serde wherever possible.