### PR TITLE
doc: Replace doc_auto_cfg with doc_cfg

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#![cfg_attr(all(doc, not(doctest)), feature(doc_auto_cfg))]
+#![cfg_attr(all(doc, not(doctest)), feature(doc_cfg))]
 //! This crate consists of incohesive generic types and functions that are
 //! needed in almost every crate but are so small that making a separate crate
 //! for them is too much.


### PR DESCRIPTION
In the newest unstable, `doc_cfg` replaces `doc_auto_cfg`. So therefore,
our docs no longer build on unstable, until we replace this.