### PR TITLE
chore: update GitHub Action pins

### DIFF
--- a/.github/workflows/ff-merge.yaml
+++ b/.github/workflows/ff-merge.yaml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Fast forwarding
-        uses: sequoia-pgp/fast-forward@v1
+        uses: sequoia-pgp/fast-forward@e2c6fb52f977408912b000ad4577a669f1c4f5fe
         with:
           merge: true
           comment: on-error

--- a/.github/workflows/rust-workflow.yml
+++ b/.github/workflows/rust-workflow.yml
@@ -28,9 +28,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: REUSE Compliance Check
-        uses: fsfe/reuse-action@v5
+        uses: fsfe/reuse-action@6ac5c823270d369f01e3c491c708f706f2bdc355
       - name: Dependency license check
-        uses: EmbarkStudios/cargo-deny-action@v2
+        uses: EmbarkStudios/cargo-deny-action@a531616d8ce3b9177443e48a1159bc945a099823
         with:
           command: check bans licenses sources
 

--- a/.github/workflows/rust-workflow.yml
+++ b/.github/workflows/rust-workflow.yml
@@ -36,7 +36,7 @@ jobs:
 
   rust:
     needs: compliance
-    uses: famedly/backend-build-workflows/.github/workflows/rust-workflow.yml@v2
+    uses: famedly/backend-build-workflows/.github/workflows/rust-workflow.yml@fcc2ec82a725d5c4c9c6a8f19e8df101c178dcb6
     secrets: inherit
     with:
       clippy_args: '--all-features'
@@ -46,7 +46,7 @@ jobs:
 
   publish:
     needs: rust
-    uses: famedly/backend-build-workflows/.github/workflows/publish-crate.yml@v2
+    uses: famedly/backend-build-workflows/.github/workflows/publish-crate.yml@fcc2ec82a725d5c4c9c6a8f19e8df101c178dcb6
     with:
       registry-name: "crates-io"
       registry-index: "https://github.com/rust-lang/crates.io-index"


### PR DESCRIPTION
## Summary
- Update GitHub Actions in workflows to the latest upstream default-branch commit SHAs.
- Keep existing action paths and only replace refs after `@`.

## Verification
- Checked generated diff to include only `.github/**/*.yml` / `.github/**/*.yaml` workflow action refs.
- CI on this PR should validate the updated action versions.